### PR TITLE
fix: TitleManagerコンポーネントのエラーログ出力修正とモジュール名の誤りを修正 #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log - Title Manager Plug-in
 
-## Unreleased-1.0.* (1)
+## 20260620-1.1 (2)
 ### Changes
+- **Fix**: Corrected missing `%s` format specifiers in `TitleManagerComponent` error logs, which previously failed to output the category name and database name (`SetExperience` / `AddExperience` / `GetExperienceRatio` / `SetProficiency` / `AddProficiency`)
+- **Fix**: Corrected an incorrect module name passed to the `IMPLEMENT_MODULE` macro in `TitleManagerEditorModule.cpp` (`TitleManagerEditorModule` → `TitleManagerEditor`)
 ### 変更点
+- **Fix**: `TitleManagerComponent` のエラーログでフォーマット文字列に `%s` が欠落しており、カテゴリ名・データベース名が出力されない不具合を修正（`SetExperience` / `AddExperience` / `GetExperienceRatio` / `SetProficiency` / `AddProficiency`）
+- **Fix**: `TitleManagerEditorModule.cpp` の `IMPLEMENT_MODULE` マクロに渡すモジュール名が誤っていた（`TitleManagerEditorModule` → `TitleManagerEditor`）問題を修正
 
-## 20241101-v1.0.0 (0)
+## 20241101-v1.0 (1)
 ### Changes
 * Initial release version
 ### 変更点

--- a/Plugins/TitleManager/Source/TitleManager/Private/TitleManagerComponent.cpp
+++ b/Plugins/TitleManager/Source/TitleManager/Private/TitleManagerComponent.cpp
@@ -110,7 +110,7 @@ int32 UTitleManagerComponent::SetExperience(const FString& categoryName, int32 e
 		FString databaseName;
 		if (TitleManagerDatabase)
 			databaseName = TitleManagerDatabase->GetName();
-		TITLE_MANAGER_ERROR(TEXT("Unable to register Category 'A' under ExperienceCategoryData 'B'.")
+		TITLE_MANAGER_ERROR(TEXT("Unable to register Category '%s' under ExperienceCategoryData '%s'.")
 			, *categoryName
 			, *databaseName
 		);
@@ -141,7 +141,7 @@ int32 UTitleManagerComponent::AddExperience(const FString& categoryName, const i
 		FString databaseName;
 		if (TitleManagerDatabase)
 			databaseName = TitleManagerDatabase->GetName();
-		TITLE_MANAGER_ERROR(TEXT("Unable to register Category 'A' under ExperienceCategoryData 'B'.")
+		TITLE_MANAGER_ERROR(TEXT("Unable to register Category '%s' under ExperienceCategoryData '%s'.")
 			, *categoryName
 			, *databaseName
 		);
@@ -171,7 +171,7 @@ float UTitleManagerComponent::GetExperienceRatio(const FString& categoryName)
 		FString databaseName;
 		if (TitleManagerDatabase)
 			databaseName = TitleManagerDatabase->GetName();
-		TITLE_MANAGER_ERROR(TEXT("Unable to register Category 'A' under ExperienceCategoryData 'B'.")
+		TITLE_MANAGER_ERROR(TEXT("Unable to register Category '%s' under ExperienceCategoryData '%s'.")
 			, *categoryName
 			, *databaseName
 		);
@@ -222,7 +222,7 @@ int32 UTitleManagerComponent::SetProficiency(const FString& categoryName, const 
 		FString databaseName;
 		if (TitleManagerDatabase)
 			databaseName = TitleManagerDatabase->GetName();
-		TITLE_MANAGER_ERROR(TEXT("Unable to register Category 'A' under ExperienceCategoryData 'B'.")
+		TITLE_MANAGER_ERROR(TEXT("Unable to register Category '%s' under ExperienceCategoryData '%s'.")
 			, *categoryName
 			, *databaseName
 		);
@@ -268,7 +268,7 @@ int32 UTitleManagerComponent::AddProficiency(const FString& categoryName, const 
 		FString databaseName;
 		if (TitleManagerDatabase)
 			databaseName = TitleManagerDatabase->GetName();
-		TITLE_MANAGER_ERROR(TEXT("Unable to register Category 'A' under ExperienceCategoryData 'B'.")
+		TITLE_MANAGER_ERROR(TEXT("Unable to register Category '%s' under ExperienceCategoryData '%s'.")
 			, *categoryName
 			, *databaseName
 		);

--- a/Plugins/TitleManager/Source/TitleManagerEditor/Private/TitleManagerEditorModule.cpp
+++ b/Plugins/TitleManager/Source/TitleManagerEditor/Private/TitleManagerEditorModule.cpp
@@ -48,4 +48,4 @@ void FTitleManagerEditorModule::ShutdownModule()
 
 #undef LOCTEXT_NAMESPACE
 
-IMPLEMENT_MODULE(FTitleManagerEditorModule, TitleManagerEditorModule)
+IMPLEMENT_MODULE(FTitleManagerEditorModule, TitleManagerEditor)

--- a/Plugins/TitleManager/TitleManager.uplugin
+++ b/Plugins/TitleManager/TitleManager.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
+	"Version": 2,
+	"VersionName": "1.1",
 	"FriendlyName": "TitleManager",
 	"Description": "Keeps track of the proficiency level of each tool and the experience level of the tool's category.",
 	"Category": "Other",


### PR DESCRIPTION
## 概要
`TitleManagerComponent` のエラーログにおいて、フォーマット文字列に実際の変数が埋め込まれずプレースホルダー文字（'A'、'B'）がそのまま出力されてしまう不具合と、`TitleManagerEditor` モジュールの `IMPLEMENT_MODULE` マクロに渡されるモジュール名が誤っていた問題を修正しました。

## 変更内容

### 1. TitleManagerComponent.cpp
`TITLE_MANAGER_ERROR` のフォーマット文字列を修正し、`categoryName` と `databaseName` が正しくログに出力されるようにしました。

- 修正前: `"Unable to register Category 'A' under ExperienceCategoryData 'B'."`
- 修正後: `"Unable to register Category '%s' under ExperienceCategoryData '%s'."`

対象箇所（5箇所）:
- `SetExperience`
- `AddExperience`
- `GetExperienceRatio`
- `SetProficiency`
- `AddProficiency`

### 2. TitleManagerEditorModule.cpp
`IMPLEMENT_MODULE` マクロに渡すモジュール名を、実際のモジュール名 `TitleManagerEditor` に修正しました（誤って `TitleManagerEditorModule` が指定されていました）。

```cpp
- IMPLEMENT_MODULE(FTitleManagerEditorModule, TitleManagerEditorModule)
+ IMPLEMENT_MODULE(FTitleManagerEditorModule, TitleManagerEditor)
```

## 修正理由
- エラーログにフォーマット引数（`*categoryName`、`*databaseName`）が渡されているにもかかわらず、フォーマット文字列側に `%s` がなかったため引数が無視され、デバッグ時に実際のカテゴリ名・データベース名が確認できない状態でした。
- `IMPLEMENT_MODULE` の第2引数はモジュール名と一致している必要があり、不一致のままだとモジュールのロード/アンロード時に問題が発生する可能性があります。

## 影響範囲
- ログ出力の内容のみが変わるため、既存のロジック・挙動への影響はありません。
- モジュール名の修正により、`TitleManagerEditor` モジュールの認識が正しくなります。
